### PR TITLE
Fix backend build: remove COPY of deleted README.md

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,7 +4,6 @@ WORKDIR /app
 COPY pyproject.toml uv.lock ./
 RUN uv sync --frozen --no-dev --no-install-project
 COPY src/ src/
-COPY README.md .
 RUN uv sync --frozen --no-dev
 
 FROM python:3.12-slim-bookworm


### PR DESCRIPTION
backend/README.md was removed in d373c62 but the Dockerfile still referenced it, causing Railway builds to fail with a 500.