### PR TITLE
feat: grey out empty filters, fix trend chart partial month

### DIFF
--- a/frontend/src/components/HeatMap.tsx
+++ b/frontend/src/components/HeatMap.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import type { MarkerData } from "../lib/types"
 
 declare const L: typeof import("leaflet")
@@ -116,6 +116,35 @@ export default function HeatMap({
 
 	const activeYears =
 		dataLayer === "encampments" ? encampmentYears : dataLayer === "waste" ? wasteYears : years
+
+	// Compute which years/months actually have data for the active layer
+	const activePoints = useMemo(() => {
+		if (dataLayer === "encampments") return encampmentPoints
+		if (dataLayer === "waste") return wastePoints
+		if (dataLayer === "both") return [...needlePoints, ...encampmentPoints]
+		return needlePoints
+	}, [dataLayer, needlePoints, encampmentPoints, wastePoints])
+
+	const availableYears = useMemo(() => {
+		const s = new Set<number>()
+		for (const [, , yr] of activePoints) s.add(yr)
+		return s
+	}, [activePoints])
+
+	const availableMonths = useMemo(() => {
+		const s = new Set<number>()
+		for (const [, , yr, mo] of activePoints) {
+			if (selYear === "all" || yr === Number(selYear)) s.add(mo)
+		}
+		return s
+	}, [activePoints, selYear])
+
+	// Reset month if current selection has no data
+	useEffect(() => {
+		if (selMonth !== 0 && !availableMonths.has(selMonth)) {
+			setSelMonth(0)
+		}
+	}, [availableMonths, selMonth])
 
 	useEffect(() => {
 		const check = () => setIsMobile(window.innerWidth < 640)
@@ -536,9 +565,15 @@ export default function HeatMap({
 								style={selectStyle}
 							>
 								<option value="all">All Years</option>
-								{activeYears.map((yr) => (
-									<option key={yr} value={String(yr)}>
+								{[...activeYears].reverse().map((yr) => (
+									<option
+										key={yr}
+										value={String(yr)}
+										disabled={!availableYears.has(yr)}
+										style={!availableYears.has(yr) ? { color: "#bbb" } : undefined}
+									>
 										{yr}
+										{!availableYears.has(yr) ? " (no data)" : ""}
 									</option>
 								))}
 							</select>
@@ -552,8 +587,14 @@ export default function HeatMap({
 							>
 								<option value={0}>All Months</option>
 								{MONTHS.map((name, i) => (
-									<option key={name} value={i + 1}>
+									<option
+										key={name}
+										value={i + 1}
+										disabled={!availableMonths.has(i + 1)}
+										style={!availableMonths.has(i + 1) ? { color: "#bbb" } : undefined}
+									>
 										{name}
+										{!availableMonths.has(i + 1) ? " (no data)" : ""}
 									</option>
 								))}
 							</select>

--- a/frontend/src/components/MonthlyTrend.tsx
+++ b/frontend/src/components/MonthlyTrend.tsx
@@ -8,7 +8,7 @@ import {
 	PointElement,
 	Tooltip,
 } from "chart.js"
-import { useEffect, useRef } from "react"
+import { useEffect, useRef, useState } from "react"
 
 Chart.register(
 	LineController,
@@ -52,45 +52,46 @@ const COLORS = [
 
 const VISIBLE_COUNT = 3
 
+function trimPartialYear(vals: number[]): (number | null)[] {
+	// Find last month with actual data (non-zero)
+	let lastNonZero = -1
+	for (let i = vals.length - 1; i >= 0; i--) {
+		if (vals[i] > 0) {
+			lastNonZero = i
+			break
+		}
+	}
+	if (lastNonZero === -1) return vals
+	// If trailing zeros exist, the last non-zero month is partial (data
+	// released monthly) — cut it off too so the line doesn't plunge
+	if (lastNonZero < vals.length - 1) {
+		const cutoff = lastNonZero - 1
+		return vals.map((v, i) => (i > cutoff ? null : v))
+	}
+	return vals
+}
+
 export default function MonthlyTrend({ yearMonthly }: MonthlyTrendProps) {
 	const canvasRef = useRef<HTMLCanvasElement>(null)
 	const chartRef = useRef<Chart | null>(null)
+	const [, setToggle] = useState(0)
 
 	useEffect(() => {
 		if (!canvasRef.current) return
 
 		const entries = Object.entries(yearMonthly)
 
-		// Data is released monthly — the most recent non-zero month in the
-		// latest year is almost certainly partial, so null it out along with
-		// all future months so the line doesn't misleadingly drop.
-		const allYears = entries.map(([yr]) => Number(yr)).sort((a, b) => a - b)
-		const latestYear = allYears[allYears.length - 1]
-		const latestVals = yearMonthly[String(latestYear)] || []
-		let lastNonZero = -1
-		for (let i = latestVals.length - 1; i >= 0; i--) {
-			if (latestVals[i] > 0) {
-				lastNonZero = i
-				break
-			}
-		}
-		const cutoffMonth = lastNonZero > 0 ? lastNonZero - 1 : -1
-
 		const datasets = entries.map(([yr, vals], i) => ({
 			label: yr,
-			data:
-				Number(yr) === latestYear && cutoffMonth >= 0
-					? vals.map((v, monthIdx) => (monthIdx > cutoffMonth ? null : v))
-					: (vals as (number | null)[]),
+			data: trimPartialYear(vals),
 			borderColor: COLORS[i % COLORS.length],
 			backgroundColor: `${COLORS[i % COLORS.length]}22`,
 			borderWidth: 2,
 			pointRadius: 3,
 			tension: 0.3,
 			fill: false,
-			spanGaps: false,
-			// Show only the most recent years by default
 			hidden: i < entries.length - VISIBLE_COUNT,
+			spanGaps: false,
 		}))
 
 		chartRef.current = new Chart(canvasRef.current, {
@@ -103,16 +104,21 @@ export default function MonthlyTrend({ yearMonthly }: MonthlyTrendProps) {
 						labels: {
 							font: { size: 11 },
 							boxWidth: 12,
-							generateLabels: (chart) =>
-								Chart.defaults.plugins.legend.labels.generateLabels(chart).map((label) => ({
+							generateLabels(chart) {
+								const original = Chart.defaults.plugins.legend.labels.generateLabels(chart)
+								return original.map((label) => ({
 									...label,
-									fontColor: label.hidden ? "#bbb" : "#333",
-								})),
+									fontColor: label.hidden ? "#888" : label.fillStyle,
+								}))
+							},
 						},
 					},
 				},
 				scales: {
-					x: { ticks: { font: { size: 10 } }, grid: { color: "rgba(0,0,0,0.05)" } },
+					x: {
+						ticks: { font: { size: 10 } },
+						grid: { color: "rgba(0,0,0,0.05)" },
+					},
 					y: {
 						ticks: { font: { size: 10 } },
 						grid: { color: "rgba(0,0,0,0.05)" },
@@ -127,31 +133,108 @@ export default function MonthlyTrend({ yearMonthly }: MonthlyTrendProps) {
 		}
 	}, [yearMonthly])
 
-	const totalYears = Object.keys(yearMonthly).length
-	const hiddenCount = totalYears - VISIBLE_COUNT
+	const hiddenCount = Object.keys(yearMonthly).length - VISIBLE_COUNT
+
+	function showAll() {
+		const chart = chartRef.current
+		if (!chart) return
+		for (const ds of chart.data.datasets) ds.hidden = false
+		chart.update()
+		setToggle((t) => t + 1)
+	}
+
+	function hideAll() {
+		const chart = chartRef.current
+		if (!chart) return
+		for (const ds of chart.data.datasets) ds.hidden = true
+		chart.update()
+		setToggle((t) => t + 1)
+	}
+
+	function soloYear(index: number) {
+		const chart = chartRef.current
+		if (!chart) return
+		for (let i = 0; i < chart.data.datasets.length; i++) {
+			chart.data.datasets[i].hidden = i !== index
+		}
+		chart.update()
+		setToggle((t) => t + 1)
+	}
 
 	return (
 		<div className="card" style={{ padding: "20px 20px 16px" }}>
 			<div
 				style={{
 					display: "flex",
-					justifyContent: "space-between",
 					alignItems: "baseline",
-					marginBottom: 2,
+					justifyContent: "space-between",
+					flexWrap: "wrap",
+					gap: 8,
+					marginBottom: 4,
 				}}
 			>
-				<div className="card-title" style={{ marginBottom: 0 }}>
+				<div className="card-title" style={{ margin: 0 }}>
 					Monthly Trend by Year
 				</div>
-				{hiddenCount > 0 && (
-					<div style={{ fontSize: "11px", color: "#888" }}>
-						{hiddenCount} more years available — click legend to toggle
-					</div>
-				)}
+				<div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+					<button type="button" onClick={showAll} style={btnStyle}>
+						Show all
+					</button>
+					<button type="button" onClick={hideAll} style={btnStyle}>
+						Clear
+					</button>
+				</div>
 			</div>
+			{hiddenCount > 0 && (
+				<div
+					style={{
+						fontSize: "11px",
+						color: "#888",
+						marginBottom: 4,
+					}}
+				>
+					Click a year in the legend to toggle it. {hiddenCount} older years hidden by default.
+				</div>
+			)}
 			<div style={{ padding: "4px 0" }}>
 				<canvas ref={canvasRef} height={180} aria-label="Monthly trend line chart by year" />
 			</div>
+			<div
+				style={{
+					display: "flex",
+					flexWrap: "wrap",
+					gap: 4,
+					marginTop: 6,
+				}}
+			>
+				{Object.keys(yearMonthly).map((yr, i) => (
+					<button
+						type="button"
+						key={yr}
+						onClick={() => soloYear(i)}
+						style={{
+							...btnStyle,
+							color: COLORS[i % COLORS.length],
+							borderColor: COLORS[i % COLORS.length],
+							fontSize: "10px",
+							padding: "1px 6px",
+						}}
+					>
+						Only {yr}
+					</button>
+				))}
+			</div>
 		</div>
 	)
+}
+
+const btnStyle: React.CSSProperties = {
+	background: "none",
+	border: "1px solid #ccc",
+	borderRadius: "4px",
+	padding: "2px 8px",
+	fontSize: "11px",
+	color: "#555",
+	cursor: "pointer",
+	lineHeight: "1.6",
 }


### PR DESCRIPTION
## Summary
- **Grey out filter options with no data** — Year/month dropdown options are disabled when the active data layer has no records for that period. E.g. switching to Encampments greys out 2015–2024 since data starts in 2025. Shows "(no data)" label on disabled options.
- **Reverse year dropdown order** — 2026 now appears first so users don't have to scroll past a decade of years.
- **Fix partial month plunge in trend chart** — Boston releases 311 data monthly, so the most recent month always has incomplete counts. Previously 2026's line dropped from 862 (March) → 55 (partial April) → 0, falsely implying a collapse in reports. Now the line cleanly ends at the last full month of data.
- **Trend chart toggle controls** — "Show all" / "Clear" buttons and per-year "Only 20XX" solo buttons. Only last 3 years shown by default with hint text explaining legend is clickable.
- Auto-resets month selection when switching to a year that lacks the selected month.

Closes #17, closes #33

## Test plan
- [ ] Switch to Encampments layer → years before 2025 should be greyed/disabled
- [ ] Select year 2026 → months May–Dec should be greyed/disabled
- [ ] Check MonthlyTrend chart: 2026 line should end at March, not drop to zero
- [ ] Click "Show all" → all years visible; "Clear" → all hidden
- [ ] Click "Only 2020" → only 2020 line visible
- [ ] Click legend items to toggle individual years

🤖 Generated with [Claude Code](https://claude.com/claude-code)