### PR TITLE
Add /data-quality page documenting 311 routing failures

### DIFF
--- a/frontend/src/pages/data-quality.astro
+++ b/frontend/src/pages/data-quality.astro
@@ -38,8 +38,10 @@ const rs = (wasteStats as Record<string, any>)?.routing_stats as
 			<h2 class="section-title">1. Your Report Gets Closed — But Nothing Happens</h2>
 			<div class="card prose">
 				<p>
-					"Closed" in Boston's 311 system does not mean "resolved." It means a city
-					worker clicked a button. For human waste reports, the data tells a stark story:
+					"Closed" in Boston's 311 system does not mean "resolved." It means the
+					ticket was marked complete — even when the receiving department had no
+					way to act on it or send it to someone who could. For human waste reports,
+					the data tells a stark story:
 				</p>
 				{rs && (
 					<div class="stats-grid">
@@ -164,10 +166,11 @@ const rs = (wasteStats as Record<string, any>)?.routing_stats as
 					<li>No department is accountable. No SLA. No follow-up.</li>
 				</ol>
 				<p>
-					The problem isn't lazy workers — it's a system that routes biohazard
-					reports to the wrong team, then counts the rejection as a resolution.
-					There is no department in Boston's 311 system whose job it is to handle
-					human waste on public streets.
+					Workers who receive these tickets have no way to reroute them. The
+					system gives them one option: close it. The report goes to the wrong
+					team, and the rejection is counted as a resolution. There is no
+					department in Boston's 311 system whose job it is to handle human
+					waste on public streets.
 				</p>
 				<div class="fix-box">
 					<strong>What should change:</strong> Assign a response team for human waste.


### PR DESCRIPTION
## Summary
- New `/data-quality` page structured for reporters/public, not developers
- Leads with human impact: your report gets closed but nothing happens (92.9% closed without action)
- Documents the full routing failure chain: no button → wrong team → rejection counted as resolution
- Includes real ticket examples from S3 data (BPW bulk-close, biohazard misrouted to street cleaning)
- Each problem section has a green "what should change" box with concrete recommendations
- Teases upcoming frustration factor analysis (repeat reporters at same location, #47)
- Technical data quality issues (stripped descriptions, missing fields, PII) moved to lower sections
- Live routing stats from waste/stats.json (will display once #45 merges)

## Related
- Closes #23
- References #47 (frustration factor)
- References #48 (routing error rate analysis)
- Depends on #45 for live routing stats (gracefully degrades without it)

## Test plan
- [ ] Visit `/data-quality` — page renders with all 7 sections
- [ ] Routing stats show if waste routing_stats available, page still works without them
- [ ] Fix boxes (green) and example boxes render correctly
- [ ] Nav links to /fix, /methodology, and home work
- [ ] Mobile layout: stats grid stacks vertically
- [ ] Read through as a non-technical person — does it tell a clear story?

🤖 Generated with [Claude Code](https://claude.com/claude-code)