### PR TITLE
feat: waste source toggle (confirmed vs ML-detected)

### DIFF
--- a/frontend/src/components/HeatMap.tsx
+++ b/frontend/src/components/HeatMap.tsx
@@ -49,6 +49,7 @@ const WASTE_GRADIENT: Record<number, string> = {
 }
 
 type DataLayer = "needles" | "encampments" | "waste" | "both"
+type WasteSource = "all" | "confirmed" | "detected"
 
 const MONTHS = [
 	"January",
@@ -65,10 +66,20 @@ const MONTHS = [
 	"December",
 ]
 
-function filterPoints(points: number[][], year: string, month: number): number[][] {
-	const filtered = points.filter(([, , yr, mo]) => {
+function filterPoints(
+	points: number[][],
+	year: string,
+	month: number,
+	sourceFilter?: WasteSource,
+): number[][] {
+	const filtered = points.filter(([, , yr, mo, src]) => {
 		if (year !== "all" && yr !== Number(year)) return false
 		if (month !== 0 && mo !== month) return false
+		if (sourceFilter && sourceFilter !== "all") {
+			const isDetected = src === 1
+			if (sourceFilter === "confirmed" && isDetected) return false
+			if (sourceFilter === "detected" && !isDetected) return false
+		}
 		return true
 	})
 	return filtered.map(([lat, lng]) => [lat, lng, 1])
@@ -100,6 +111,8 @@ export default function HeatMap({
 	const [selMonth, setSelMonth] = useState(0)
 	const [dataLayer, setDataLayer] = useState<DataLayer>("both")
 	const dataLayerRef = useRef<DataLayer>("both")
+	const [wasteSource, setWasteSource] = useState<WasteSource>("all")
+	const wasteSourceRef = useRef<WasteSource>("all")
 	const selYearRef = useRef(defaultYear)
 	const selMonthRef = useRef(0)
 	const [count, setCount] = useState(
@@ -300,17 +313,25 @@ export default function HeatMap({
 		}
 
 		if (layer === "waste" && wasteMarkerGroupRef.current) {
+			const srcFilter = wasteSourceRef.current
 			for (const m of wasteMarkers.filter(filterMarker)) {
+				if (srcFilter !== "all") {
+					const mSrc = m.source || "confirmed"
+					if (srcFilter !== mSrc) continue
+				}
+				const isDetected = m.source === "detected"
+				const color = isDetected ? "#C4841D" : "#8B6914"
+				const label = isDetected ? "Missed Report" : "311 Ticket"
 				L.circleMarker([m.lat, m.lng], {
 					radius: 5,
-					fillColor: "#8B6914",
-					fillOpacity: 0.85,
+					fillColor: color,
+					fillOpacity: isDetected ? 0.7 : 0.85,
 					color: "#fff",
 					weight: 1,
 					opacity: 0.6,
 				})
 					.bindPopup(
-						`<div style="font-size:12px;line-height:1.6;color:#222"><b style="font-size:13px;color:#8B6914;display:block">Human Waste: ${m.hood || "Unknown"}</b>${m.street || ""}<br>${m.dt}${m.zip ? ` &middot; ${m.zip}` : ""}</div>`,
+						`<div style="font-size:12px;line-height:1.6;color:#222"><b style="font-size:13px;color:${color};display:block">Human Waste (${label}): ${m.hood || "Unknown"}</b>${m.street || ""}<br>${m.dt}${m.zip ? ` &middot; ${m.zip}` : ""}</div>`,
 					)
 					.addTo(wasteMarkerGroupRef.current as L.LayerGroup)
 			}
@@ -334,6 +355,7 @@ export default function HeatMap({
 	// biome-ignore lint/correctness/useExhaustiveDependencies: intentional dependency on dataLayer
 	useEffect(() => {
 		dataLayerRef.current = dataLayer
+		wasteSourceRef.current = wasteSource
 		if (!ready || !mapInstance.current) return
 		const map = mapInstance.current
 
@@ -369,24 +391,32 @@ export default function HeatMap({
 		}
 
 		if (dataLayer === "waste") {
-			const pts = filterPoints(wastePoints, defaultYear, 0)
+			const pts = filterPoints(wastePoints, defaultYear, 0, wasteSource)
 			const layer = createHeatLayer(pts, WASTE_GRADIENT)
 			layer.addTo(map)
 			wasteHeatLayerRef.current = layer
-			setWasteCount(wastePoints.filter(([, , yr]) => String(yr) === defaultYear).length)
+			setWasteCount(
+				wastePoints.filter(([, , yr, , src]) => {
+					if (String(yr) !== defaultYear) return false
+					if (wasteSource === "confirmed" && src === 1) return false
+					if (wasteSource === "detected" && src !== 1) return false
+					return true
+				}).length,
+			)
 		}
 
 		// Re-show markers if zoomed in and pins enabled
 		if (showPins && map.getZoom() >= 15) {
 			rebuildMarkers(map)
 		}
-	}, [dataLayer, ready])
+	}, [dataLayer, wasteSource, ready])
 
 	// Filter heatmap data client-side when filter changes
-	// biome-ignore lint/correctness/useExhaustiveDependencies: filtering depends on selYear/selMonth/dataLayer
+	// biome-ignore lint/correctness/useExhaustiveDependencies: filtering depends on selYear/selMonth/dataLayer/wasteSource
 	useEffect(() => {
 		selYearRef.current = selYear
 		selMonthRef.current = selMonth
+		wasteSourceRef.current = wasteSource
 		if (!ready || !mapInstance.current) return
 		const map = mapInstance.current
 
@@ -420,13 +450,15 @@ export default function HeatMap({
 
 		if (dataLayer === "waste") {
 			if (wasteHeatLayerRef.current) map.removeLayer(wasteHeatLayerRef.current)
-			const pts = filterPoints(wastePoints, selYear, selMonth)
+			const pts = filterPoints(wastePoints, selYear, selMonth, wasteSource)
 			const layer = createHeatLayer(pts, WASTE_GRADIENT)
 			layer.addTo(map)
 			wasteHeatLayerRef.current = layer
-			const filteredCount = wastePoints.filter(([, , yr, mo]) => {
+			const filteredCount = wastePoints.filter(([, , yr, mo, src]) => {
 				if (selYear !== "all" && yr !== Number(selYear)) return false
 				if (selMonth !== 0 && mo !== selMonth) return false
+				if (wasteSource === "confirmed" && src === 1) return false
+				if (wasteSource === "detected" && src !== 1) return false
 				return true
 			}).length
 			setWasteCount(filteredCount)
@@ -436,7 +468,7 @@ export default function HeatMap({
 		if (map.getZoom() >= 15) {
 			rebuildMarkers(map)
 		}
-	}, [selYear, selMonth, ready, dataLayer])
+	}, [selYear, selMonth, ready, dataLayer, wasteSource])
 
 	const showFilterPanel = !isMobile || filterOpen
 
@@ -557,6 +589,21 @@ export default function HeatMap({
 							Show pins when zoomed in
 						</label>
 
+						{dataLayer === "waste" && (
+							<div style={{ marginBottom: 8 }}>
+								<div style={filterLabelStyle}>Source</div>
+								<select
+									value={wasteSource}
+									onChange={(e) => setWasteSource(e.target.value as WasteSource)}
+									style={selectStyle}
+								>
+									<option value="all">All Reports</option>
+									<option value="confirmed">311 Tickets</option>
+									<option value="detected">Missed (ML)</option>
+								</select>
+							</div>
+						)}
+
 						<div style={{ marginBottom: 8 }}>
 							<div style={filterLabelStyle}>Year</div>
 							<select
@@ -631,7 +678,12 @@ export default function HeatMap({
 					)}
 					{dataLayer === "waste" && (
 						<span style={{ color: "#8B6914" }}>
-							<strong>{wasteCount.toLocaleString()}</strong> human waste reports
+							<strong>{wasteCount.toLocaleString()}</strong>{" "}
+							{wasteSource === "confirmed"
+								? "confirmed 311 tickets"
+								: wasteSource === "detected"
+									? "missed reports (ML)"
+									: "human waste reports"}
 							<span style={{ fontSize: "10px", opacity: 0.7 }}> (beta)</span>
 						</span>
 					)}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -19,6 +19,7 @@ export interface MarkerData {
 	hood: string
 	street: string
 	zip: string
+	source?: "confirmed" | "detected" | null
 }
 
 export interface PageStats {

--- a/pipeline/src/pipeline/analytics.py
+++ b/pipeline/src/pipeline/analytics.py
@@ -48,8 +48,11 @@ def compute_stats(records: list[CleanedRecord]) -> DashboardStats:
         if mo_recs:
             heat_keys[f"all-{m:02d}"] = _bin_records(mo_recs)
 
-    # Compact point array: [lat, lng, year, month]
-    points: list[list[float | int]] = [[r.lat, r.lng, r.year, r.month] for r in records]
+    # Compact point array: [lat, lng, year, month, source_flag]
+    # source_flag: 0 = confirmed (or no source), 1 = detected
+    points: list[list[float | int]] = [
+        [r.lat, r.lng, r.year, r.month, 1 if r.source == "detected" else 0] for r in records
+    ]
 
     # Neighborhood breakdown
     by_hood: dict[str, list[CleanedRecord]] = defaultdict(list)
@@ -87,7 +90,8 @@ def compute_stats(records: list[CleanedRecord]) -> DashboardStats:
     # Individual markers (cap at 3000 most recent)
     recent = sorted(records, key=lambda r: r.dt, reverse=True)[:3000]
     markers = [
-        MarkerData(lat=r.lat, lng=r.lng, dt=r.dt[:10], hood=r.hood, street=r.street, zip=r.zipcode) for r in recent
+        MarkerData(lat=r.lat, lng=r.lng, dt=r.dt[:10], hood=r.hood, street=r.street, zip=r.zipcode, source=r.source)
+        for r in recent
     ]
 
     dow = Counter(r.dow for r in records)

--- a/pipeline/src/pipeline/models.py
+++ b/pipeline/src/pipeline/models.py
@@ -17,6 +17,7 @@ class CleanedRecord(BaseModel):
     street: str
     zipcode: str
     resp_hrs: float | None = None
+    source: str | None = None  # "confirmed" or "detected" (waste only)
 
 
 class NeighborhoodStat(BaseModel):
@@ -46,6 +47,7 @@ class MarkerData(BaseModel):
     hood: str
     street: str
     zip: str
+    source: str | None = None  # "confirmed" or "detected" (waste only)
 
 
 class DashboardStats(BaseModel):

--- a/pipeline/src/pipeline/run.py
+++ b/pipeline/src/pipeline/run.py
@@ -185,6 +185,8 @@ def _process_waste(raw_records: list[dict[str, Any]], force: bool) -> int:
     for row in all_matches:
         cleaned_rec = clean(row)
         if cleaned_rec is not None:
+            queue = row.get("queue", "")
+            cleaned_rec.source = "confirmed" if "HumanWaste" in queue else "detected"
             cleaned.append(cleaned_rec)
 
     if not cleaned:


### PR DESCRIPTION
## Summary
- Pipeline now tags each waste record as `"confirmed"` (routed to `INFO_HumanWaste` queue) or `"detected"` (found by ML classifier in misrouted tickets)
- Frontend adds a **Source** sub-toggle when the Human Waste layer is selected: All Reports / 311 Tickets / Missed (ML)
- Both heatmap and zoom-in markers filter by source, with different colors and popup labels
- Points array gains a 5th element (source flag) for client-side filtering

## Note
Existing S3 data doesn't have the `source` field yet — **requires a pipeline re-run** (`uv run boston-pipeline run -d waste --force`) to populate it. Until then, all records default to "confirmed" and the "Missed (ML)" filter shows 0.

## Test plan
- [ ] Run pipeline with `--force` to regenerate waste data with source tags
- [ ] Verify "All Reports" shows the same count as before
- [ ] Verify "311 Tickets" shows only confirmed queue records
- [ ] Verify "Missed (ML)" shows ML-detected misrouted records
- [ ] Verify marker popups show correct labels ("311 Ticket" vs "Missed Report")
- [ ] Verify count badge updates when toggling source filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)