### PR TITLE
fix: pin en_core_web_sm as a direct URL dep

### DIFF
--- a/pipeline/Dockerfile
+++ b/pipeline/Dockerfile
@@ -4,7 +4,8 @@ COPY pipeline/pyproject.toml pipeline/uv.lock ./
 RUN uv sync --frozen --no-dev --no-install-project
 COPY pipeline/src/ src/
 RUN uv sync --frozen --no-dev
-RUN uv run python -m spacy download en_core_web_sm
+# en_core_web_sm is declared as a direct URL dep in pyproject.toml, so
+# `uv sync` above installs it. No separate `spacy download` step needed.
 
 FROM python:3.12-slim-bookworm
 RUN groupadd --gid 1000 appuser && useradd --uid 1000 --gid 1000 --no-create-home appuser

--- a/pipeline/pyproject.toml
+++ b/pipeline/pyproject.toml
@@ -10,6 +10,10 @@ dependencies = [
     "boto3>=1.35.0",
     "spacy>=3.8.0",
     "tenacity>=9.0.0",
+    # spaCy English model — pinned as a direct URL dep so `uv sync` installs it
+    # reliably. Without this it silently disappears from the venv every time
+    # `uv sync` runs, breaking the waste classifier locally.
+    "en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl",
 ]
 
 [project.scripts]
@@ -18,6 +22,11 @@ boston-pipeline = "pipeline.cli:app"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.metadata]
+# Required so the en_core_web_sm direct URL dep in [project.dependencies]
+# is accepted by hatchling.
+allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/pipeline"]

--- a/pipeline/uv.lock
+++ b/pipeline/uv.lock
@@ -71,6 +71,7 @@ version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },
+    { name = "en-core-web-sm" },
     { name = "pydantic" },
     { name = "python-dateutil" },
     { name = "spacy" },
@@ -90,6 +91,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "boto3", specifier = ">=1.35.0" },
+    { name = "en-core-web-sm", url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl" },
     { name = "pydantic", specifier = ">=2.10.0" },
     { name = "python-dateutil", specifier = ">=2.9.0.post0" },
     { name = "spacy", specifier = ">=3.8.0" },
@@ -450,6 +452,14 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/01/ffe51729a8f961a437920560659073e47f575d4627445216c1177ecd4a41/cymem-2.0.13-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:666ce6146bc61b9318aa70d91ce33f126b6344a25cf0b925621baed0c161e9cc", size = 290465 },
     { url = "https://files.pythonhosted.org/packages/fd/ac/c9e7d68607f71ef978c81e334ab2898b426944c71950212b1467186f69f9/cymem-2.0.13-cp314-cp314t-win_amd64.whl", hash = "sha256:84c1168c563d9d1e04546cb65e3e54fde2bf814f7c7faf11fc06436598e386d1", size = 46665 },
     { url = "https://files.pythonhosted.org/packages/66/66/150e406a2db5535533aa3c946de58f0371f2e412e23f050c704588023e6e/cymem-2.0.13-cp314-cp314t-win_arm64.whl", hash = "sha256:e9027764dc5f1999fb4b4cabee1d0322c59e330c0a6485b436a68275f614277f", size = 39715 },
+]
+
+[[package]]
+name = "en-core-web-sm"
+version = "3.8.0"
+source = { url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl" }
+wheels = [
+    { url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl", hash = "sha256:1932429db727d4bff3deed6b34cfc05df17794f4a52eeb26cf8928f7c1a0fb85" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The spaCy English model `en_core_web_sm` was installed **ad-hoc** via `pipeline/Dockerfile` (`RUN uv run python -m spacy download en_core_web_sm`) and was **not declared in `pyproject.toml`**.

Consequence: any `uv sync` run locally silently removes the model from the venv, because `uv sync` enforces that the venv should match what is declared. This breaks `pipeline/src/pipeline/classifier.py:38` (`spacy.load("en_core_web_sm", ...)`) and thus the entire waste classifier, with no warning.

This PR declares the model as a **direct URL dep** pinned to 3.8.0 so `uv sync` installs it reliably, and drops the Dockerfile's separate `spacy download` step.

## Changes

- `pipeline/pyproject.toml`:
  - Add `en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.8.0/en_core_web_sm-3.8.0-py3-none-any.whl` to `[project.dependencies]`
  - Add `[tool.hatch.metadata] allow-direct-references = true` so hatchling accepts the direct URL reference
- `pipeline/uv.lock`: regenerated
- `pipeline/Dockerfile`: remove `RUN uv run python -m spacy download en_core_web_sm` (now handled by `uv sync`)

## Why not just document "remember to re-download the model"?

Because humans forget. I literally hit this today while adding an unrelated dep — `uv sync` removed the model without warning. A declared dep is self-enforcing; documentation is not.

## Verification

```
$ uv sync --reinstall-package en_core_web_sm
...
 ~ en-core-web-sm==3.8.0 (from https://.../en_core_web_sm-3.8.0-py3-none-any.whl)

$ uv run python -c "import spacy; print(spacy.load('en_core_web_sm').meta['version'])"
3.8.0
```

## Test plan

- [x] `uv sync --reinstall-package en_core_web_sm` pulls the wheel
- [x] `spacy.load("en_core_web_sm")` works after a clean sync
- [x] `uv run ruff check src/ tests/` passes
- [x] `uv run ruff format --check src/ tests/` passes
- [x] `uv run mypy src/` passes (strict mode)
- [x] `uv run pytest` passes (7/7)
- [ ] CI builds the Docker image successfully without the explicit `spacy download` step

Generated with Claude Code
