### PR TITLE
ci: add frontend build check to PR workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -90,6 +90,29 @@ jobs:
       - name: Check
         run: pnpm check
 
+  frontend-build:
+    name: Frontend Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Build (no S3 — uses empty fallback data)
+        run: pnpm build
+
   secret-scanning:
     name: Scan for secrets
     runs-on: ubuntu-latest
@@ -131,7 +154,7 @@ jobs:
     name: All Checks Pass
     runs-on: ubuntu-latest
     if: always()
-    needs: [pipeline-ruff-lint, pipeline-ruff-format, pipeline-mypy, pipeline-test, frontend-check, secret-scanning]
+    needs: [pipeline-ruff-lint, pipeline-ruff-format, pipeline-mypy, pipeline-test, frontend-check, frontend-build, secret-scanning]
     steps:
       - name: Verify all checks passed
         run: |
@@ -140,6 +163,7 @@ jobs:
                 "${{ needs.pipeline-mypy.result }}" != "success" ||
                 "${{ needs.pipeline-test.result }}" != "success" ||
                 "${{ needs.frontend-check.result }}" != "success" ||
+                "${{ needs.frontend-build.result }}" != "success" ||
                 "${{ needs.secret-scanning.result }}" != "success" ]]; then
             echo "One or more checks failed."
             exit 1


### PR DESCRIPTION
## Summary
- Adds `frontend-build` job to CI that runs `pnpm build` on every PR
- Catches type errors, import failures, and Astro rendering issues before merge
- Runs without S3 credentials — uses empty fallback data so it doesn't need real bucket access
- Added to the `all-checks-pass` gate so PRs can't merge if the build fails

## Why
We're self-merging frontend/content PRs without Scott's review. The `year_hourly` type error that took down prod (#69) would have been caught by this build step. With less reviewer oversight, CI needs to be the safety net.

## Test plan
- [ ] Verify the new `Frontend Build` check appears on this PR
- [ ] Verify it passes (build succeeds with empty fallback data)
- [ ] Verify `All Checks Pass` gate includes the new check

🤖 Generated with [Claude Code](https://claude.com/claude-code)