### PR TITLE
feat: integrate scraped Open311 data into pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .playwright-mcp/
+.worktrees/
 
 # Python
 __pycache__/

--- a/pipeline/src/pipeline/config.py
+++ b/pipeline/src/pipeline/config.py
@@ -148,6 +148,13 @@ FALSE_POSITIVE_CONTEXTS: set[str] = {
 # Standard BPW rejection phrase — strong positive signal
 BPW_REJECTION_PATTERN = "bpw does not service human waste"
 
+# --- Open311 scraper S3 prefixes ---
+
+OPEN311_SCRAPER_PREFIX = "open311"
+SCRAPER_SLUGS_FOR_WASTE = ["street-cleaning"]
+SCRAPER_SLUGS_FOR_ENCAMPMENTS = ["encampments"]
+SCRAPER_SLUGS_FOR_NEEDLES = ["needles"]
+
 # --- S3 / Railway bucket storage ---
 
 BUCKET = os.environ.get("BUCKET", "")

--- a/pipeline/src/pipeline/enricher.py
+++ b/pipeline/src/pipeline/enricher.py
@@ -1,9 +1,16 @@
-"""Enrich 311 records with Open311 API description field."""
+"""Enrich 311 records with Open311 API description field.
 
+Supports two enrichment paths:
+  1. Bulk S3 — loads pre-scraped descriptions from open311/{slug}/ day-files
+  2. API fallback — fetches individual descriptions for any records not in S3
+"""
+
+import contextlib
 import json
 import logging
 import time
 import urllib.request
+from datetime import date
 from typing import Any
 
 from pipeline.config import OPEN311_BASE, UA
@@ -32,15 +39,42 @@ def enrich_records(
     description_cache: dict[str, str | None],
     delay: float = 0.2,
     max_records: int | None = None,
+    slugs: list[str] | None = None,
 ) -> tuple[list[dict[str, Any]], dict[str, str | None]]:
     """Enrich records with Open311 descriptions.
 
-    Instead of using filesystem caching, accepts a description_cache dict
-    and returns (enriched_records, updated_cache). The caller is responsible
-    for loading/saving the cache from S3.
+    Strategy:
+      1. If slugs provided, bulk-load descriptions from scraped S3 data
+      2. Apply any S3-sourced descriptions to records + update cache
+      3. Fall back to individual API lookups for anything still unresolved
+
+    Accepts a description_cache dict and returns (enriched_records, updated_cache).
+    The caller is responsible for loading/saving the cache from S3.
     """
     to_process = records[:max_records] if max_records else records
+
+    # --- Phase 1: Bulk S3 lookup ---
+    s3_descriptions: dict[str, dict[str, str | None]] = {}
+    if slugs:
+        from pipeline.open311_loader import load_descriptions_from_s3
+
+        # Determine date range from records
+        dates: list[date] = []
+        for rec in to_process:
+            open_dt = rec.get("open_dt") or rec.get("OPEN_DT") or ""
+            if open_dt:
+                with contextlib.suppress(ValueError):
+                    dates.append(date.fromisoformat(open_dt[:10]))
+
+        if dates:
+            start = min(dates)
+            end = max(dates)
+            s3_descriptions = load_descriptions_from_s3(slugs, start, end)
+            logger.info("Loaded %d descriptions from S3 scrape", len(s3_descriptions))
+
+    # --- Phase 2: Apply descriptions ---
     enriched = 0
+    from_s3 = 0
     skipped = 0
     failed = 0
 
@@ -51,11 +85,22 @@ def enrich_records(
 
         case_id = str(case_id)
 
+        # Check in-memory cache first
         if case_id in description_cache:
             record["open311_description"] = description_cache[case_id]
             skipped += 1
             continue
 
+        # Check S3 bulk data
+        if case_id in s3_descriptions:
+            desc = s3_descriptions[case_id].get("description")
+            description_cache[case_id] = desc
+            record["open311_description"] = desc
+            from_s3 += 1
+            enriched += 1
+            continue
+
+        # Fall back to individual API lookup
         description = fetch_open311_description(case_id)
         description_cache[case_id] = description
         record["open311_description"] = description
@@ -68,15 +113,22 @@ def enrich_records(
         # Progress update every 50 records
         if (i + 1) % 50 == 0:
             logger.info(
-                "  ... %d/%d (enriched: %d, cached: %d, failed: %d)",
+                "  ... %d/%d (enriched: %d, s3: %d, cached: %d, failed: %d)",
                 i + 1,
                 len(to_process),
                 enriched,
+                from_s3,
                 skipped,
                 failed,
             )
 
         time.sleep(delay)
 
-    logger.info("Enrichment complete: %d new, %d cached, %d failed", enriched, skipped, failed)
+    logger.info(
+        "Enrichment complete: %d new (%d from S3), %d cached, %d failed",
+        enriched,
+        from_s3,
+        skipped,
+        failed,
+    )
     return to_process, description_cache

--- a/pipeline/src/pipeline/open311_loader.py
+++ b/pipeline/src/pipeline/open311_loader.py
@@ -1,0 +1,86 @@
+"""Load scraped Open311 data from S3 for bulk description enrichment."""
+
+import logging
+import re
+from datetime import date
+from typing import Any
+
+from pipeline import storage
+from pipeline.config import OPEN311_SCRAPER_PREFIX
+
+logger = logging.getLogger(__name__)
+
+# Pattern to extract date from S3 key like "open311/street-cleaning/2024-01-15.json"
+_DATE_RE = re.compile(r"(\d{4}-\d{2}-\d{2})\.json$")
+
+
+def load_descriptions_from_s3(
+    slugs: list[str],
+    start_date: date,
+    end_date: date,
+) -> dict[str, dict[str, str | None]]:
+    """Load scraped Open311 records from S3.
+
+    Returns {service_request_id: {description, media_url, status_notes}}.
+    """
+    result: dict[str, dict[str, str | None]] = {}
+    total_loaded = 0
+
+    for slug in slugs:
+        prefix = f"{OPEN311_SCRAPER_PREFIX}/{slug}/"
+        keys = storage.list_keys(prefix)
+
+        day_keys: list[str] = []
+        for key in keys:
+            match = _DATE_RE.search(key)
+            if not match:
+                continue
+            key_date = date.fromisoformat(match.group(1))
+            if start_date <= key_date <= end_date:
+                day_keys.append(key)
+
+        logger.info("Loading %d day-files from s3 for slug=%s", len(day_keys), slug)
+
+        for key in day_keys:
+            records = storage.read_json(key)
+            if not records or not isinstance(records, list):
+                continue
+
+            for record in records:
+                sr_id = record.get("service_request_id")
+                if not sr_id:
+                    continue
+
+                result[str(sr_id)] = {
+                    "description": record.get("description"),
+                    "media_url": record.get("media_url"),
+                    "status_notes": record.get("status_notes"),
+                }
+                total_loaded += 1
+
+    logger.info("Loaded %d Open311 descriptions from S3 across %d slugs", total_loaded, len(slugs))
+    return result
+
+
+def normalize_open311_record(record: dict[str, Any]) -> dict[str, Any]:
+    """Convert Open311 API fields to CKAN-like format for clean().
+
+    Maps Open311 field names to the column names the pipeline expects from CKAN.
+    Used for Phase 2 "Other" ticket ingestion where we have no CKAN equivalent.
+    """
+    return {
+        "case_enquiry_id": record.get("service_request_id", ""),
+        "open_dt": record.get("requested_datetime", ""),
+        "closed_dt": record.get("updated_datetime", ""),
+        "case_title": record.get("service_name", ""),
+        "subject": record.get("service_name", ""),
+        "type": record.get("service_name", ""),
+        "queue": record.get("service_code", ""),
+        "latitude": record.get("lat"),
+        "longitude": record.get("long"),
+        "neighborhood": record.get("address", ""),
+        "location_street_name": record.get("address", ""),
+        "location_zipcode": record.get("zipcode", ""),
+        "closure_reason": record.get("status_notes", ""),
+        "open311_description": record.get("description"),
+    }

--- a/pipeline/src/pipeline/run.py
+++ b/pipeline/src/pipeline/run.py
@@ -14,6 +14,7 @@ from pipeline.config import (
     ENCAMPMENT_TYPES,
     NEEDLE_TYPES,
     RESOURCE_IDS,
+    SCRAPER_SLUGS_FOR_WASTE,
     STREET_CLEANING_TYPES,
 )
 from pipeline.enricher import enrich_records
@@ -220,7 +221,11 @@ def _process_waste(raw_records: list[dict[str, Any]], force: bool) -> int:
     description_cache: dict[str, str | None] = storage.read_json("enriched/descriptions.json") or {}
     logger.info("Loaded %d cached descriptions", len(description_cache))
 
-    enriched_records, description_cache = enrich_records(to_enrich, description_cache)
+    enriched_records, description_cache = enrich_records(
+        to_enrich,
+        description_cache,
+        slugs=SCRAPER_SLUGS_FOR_WASTE,
+    )
     storage.write_json("enriched/descriptions.json", description_cache)
 
     # Step 4: Re-classify enriched records (descriptions may reveal more signal)

--- a/pipeline/src/pipeline/storage.py
+++ b/pipeline/src/pipeline/storage.py
@@ -61,11 +61,14 @@ def file_exists(key: str, bucket: str | None = None) -> bool:
 
 
 def list_keys(prefix: str, bucket: str | None = None) -> list[str]:
-    """List object keys under a prefix."""
+    """List all object keys under a prefix (handles >1000 results)."""
     bucket = bucket or BUCKET
     try:
-        resp = _get_client().list_objects_v2(Bucket=bucket, Prefix=prefix)
-        return [obj["Key"] for obj in resp.get("Contents", [])]
+        paginator = _get_client().get_paginator("list_objects_v2")
+        keys: list[str] = []
+        for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+            keys.extend(obj["Key"] for obj in page.get("Contents", []))
+        return keys
     except Exception:
         logger.warning("Failed to list s3://%s/%s", bucket, prefix, exc_info=True)
         return []

--- a/services/open311-scraper/fetch.py
+++ b/services/open311-scraper/fetch.py
@@ -29,7 +29,9 @@ Usage:
 import argparse
 import json
 import logging
+import math
 import os
+import random
 import sys
 import time
 import urllib.parse
@@ -118,6 +120,10 @@ SERVICE_TYPES: dict[str, tuple[str, str]] = {
     "illegal-trash": (
         "Public Works Department:Code Enforcement:Improper Storage of Trash (Barrels)",
         "Residential Trash out Illegally",
+    ),
+    "street-cleaning": (
+        "Public Works Department:Street Cleaning:Requests for Street Cleaning",
+        "Requests for Street Cleaning",
     ),
 }
 
@@ -222,8 +228,9 @@ def fetch_day(day: date, service_code: str, delay: float) -> tuple[list[dict], f
             try:
                 data, retry_after = _do_request(url)
             except Exception as e:
-                log.error("  ERROR %s page %d: %s", day, page, e)
-                return all_records, delay
+                log.error("  ERROR %s page %d: %s (discarding %d partial records)",
+                          day, page, e, len(all_records))
+                return [], delay
 
             if data is not None:
                 break
@@ -310,6 +317,201 @@ def fetch_type(
     }
 
 
+def _fetch_api_count(day: date, service_code: str, delay: float) -> tuple[int, float]:
+    """Fetch the actual record count for a day from the API.
+
+    Fetches all records and counts them (no shortcut for count-only).
+    Returns (count, updated_delay).
+    """
+    records, delay = fetch_day(day, service_code, delay)
+    return len(records), delay
+
+
+def _verify_type(
+    s3,
+    slug: str,
+    service_code: str,
+    name: str,
+    start: date,
+    end: date,
+    delay: float,
+    sample_rate: float,
+) -> dict:
+    """Run verification checks on existing scraped data for one type.
+
+    Checks:
+      1. Gap detection — find missing days, re-fetch them
+      2. Record count verification — compare stored vs API counts
+      3. Cross-day consistency — flag days far below neighbors' average
+    """
+    prefix = f"open311/{slug}/"
+    existing = list_existing_days(s3, prefix)
+
+    # Build full date range
+    all_days: list[date] = []
+    current = start
+    while current <= end:
+        all_days.append(current)
+        current += timedelta(days=1)
+
+    stats = {
+        "slug": slug,
+        "name": name,
+        "total_days_in_range": len(all_days),
+        "existing_days": len(existing),
+        "gaps_found": 0,
+        "gaps_filled": 0,
+        "suspicious_zeros": 0,
+        "partial_detected": 0,
+        "count_verified_ok": 0,
+        "count_mismatch": 0,
+        "consistency_flagged": 0,
+    }
+
+    # --- Check 1: Gap detection (missing days) ---
+    missing_days = [d for d in all_days if str(d) not in existing]
+    stats["gaps_found"] = len(missing_days)
+    log.info("[%s] Gap detection: %d missing days out of %d", slug, len(missing_days), len(all_days))
+
+    for day in missing_days:
+        records, delay = fetch_day(day, service_code, delay)
+        if records:
+            save_day(s3, prefix, day, records)
+            stats["gaps_filled"] += 1
+            log.info("  [%s] Gap filled: %s (%d records)", slug, day, len(records))
+        else:
+            stats["suspicious_zeros"] += 1
+            log.warning("  [%s] Suspicious zero: %s (no records from API)", slug, day)
+        time.sleep(delay)
+
+    # Refresh existing days after gap filling
+    existing = list_existing_days(s3, prefix)
+
+    # --- Check 2: Record count verification ---
+    existing_sorted = sorted(existing)
+    if sample_rate < 1.0:
+        sample_size = max(1, int(len(existing_sorted) * sample_rate))
+        days_to_check = random.sample(existing_sorted, sample_size)
+        log.info("[%s] Record count check: sampling %d/%d days (%.0f%%)",
+                 slug, len(days_to_check), len(existing_sorted), sample_rate * 100)
+    else:
+        days_to_check = existing_sorted
+        log.info("[%s] Record count check: full scan of %d days", slug, len(days_to_check))
+
+    for day_str in days_to_check:
+        day = date.fromisoformat(day_str)
+        key = f"{prefix}{day}.json"
+
+        # Get stored count from metadata
+        try:
+            resp = s3.head_object(Bucket=BUCKET, Key=key)
+            stored_count_str = resp.get("Metadata", {}).get("record-count")
+            if stored_count_str is None:
+                continue
+            stored_count = int(stored_count_str)
+        except Exception:
+            continue
+
+        # Fetch actual count from API
+        api_count, delay = _fetch_api_count(day, service_code, delay)
+        time.sleep(delay)
+
+        if api_count == 0:
+            # API returned nothing — can't verify, skip
+            continue
+
+        if stored_count < api_count:
+            # Partial data — delete so next regular run re-fetches
+            s3.delete_object(Bucket=BUCKET, Key=key)
+            stats["partial_detected"] += 1
+            log.warning("  [%s] PARTIAL %s: stored %d < API %d — deleted for re-fetch",
+                        slug, day, stored_count, api_count)
+        elif stored_count > api_count:
+            log.info("  [%s] OVER-COUNT %s: stored %d > API %d (API may have deduped)",
+                     slug, day, stored_count, api_count)
+            stats["count_verified_ok"] += 1
+        else:
+            stats["count_verified_ok"] += 1
+
+    # --- Check 3: Cross-day consistency ---
+    # Load record counts for all existing days to compute rolling averages
+    day_counts: dict[str, int] = {}
+    for day_str in existing_sorted:
+        key = f"{prefix}{day_str}.json"
+        try:
+            resp = s3.head_object(Bucket=BUCKET, Key=key)
+            count_str = resp.get("Metadata", {}).get("record-count")
+            if count_str is not None:
+                day_counts[day_str] = int(count_str)
+        except Exception:
+            continue
+
+    if len(day_counts) >= 7:
+        sorted_days = sorted(day_counts.keys())
+        counts_list = [day_counts[d] for d in sorted_days]
+
+        for i, day_str in enumerate(sorted_days):
+            # Use a 7-day window centered on this day
+            window_start = max(0, i - 3)
+            window_end = min(len(counts_list), i + 4)
+            neighbors = counts_list[window_start:i] + counts_list[i + 1:window_end]
+
+            if not neighbors:
+                continue
+
+            avg = sum(neighbors) / len(neighbors)
+            if avg > 0 and day_counts[day_str] <= avg * 0.5:
+                stats["consistency_flagged"] += 1
+                log.warning("  [%s] CONSISTENCY %s: %d records vs %.0f neighbor avg (%.0f%%)",
+                            slug, day_str, day_counts[day_str], avg,
+                            day_counts[day_str] / avg * 100 if avg > 0 else 0)
+
+    return stats
+
+
+def run_verify(
+    s3,
+    types_to_verify: dict[str, tuple[str, str]],
+    start: date,
+    end: date,
+    delay: float,
+    sample_rate: float,
+) -> None:
+    """Run verify mode across all requested types and write report."""
+    all_stats = []
+    for slug, (service_code, name) in types_to_verify.items():
+        log.info("=== Verifying [%s] %s ===", slug, name)
+        stats = _verify_type(s3, slug, service_code, name, start, end, delay, sample_rate)
+        all_stats.append(stats)
+
+        log.info("[%s] Summary: %d gaps found, %d filled, %d suspicious zeros, "
+                 "%d partial deleted, %d verified OK, %d consistency flagged",
+                 slug, stats["gaps_found"], stats["gaps_filled"],
+                 stats["suspicious_zeros"], stats["partial_detected"],
+                 stats["count_verified_ok"], stats["consistency_flagged"])
+
+    # Write report
+    report = {
+        "run_time": datetime.utcnow().isoformat() + "Z",
+        "date_range": {"start": str(start), "end": str(end)},
+        "sample_rate": sample_rate,
+        "types": all_stats,
+        "totals": {
+            "gaps_found": sum(s["gaps_found"] for s in all_stats),
+            "gaps_filled": sum(s["gaps_filled"] for s in all_stats),
+            "suspicious_zeros": sum(s["suspicious_zeros"] for s in all_stats),
+            "partial_detected": sum(s["partial_detected"] for s in all_stats),
+            "count_verified_ok": sum(s["count_verified_ok"] for s in all_stats),
+            "consistency_flagged": sum(s["consistency_flagged"] for s in all_stats),
+        },
+    }
+
+    key = "open311/verify_report.json"
+    body = json.dumps(report, indent=2, default=str)
+    s3.put_object(Bucket=BUCKET, Key=key, Body=body.encode("utf-8"), ContentType="application/json")
+    log.info("Verify report written to s3://%s/%s", BUCKET, key)
+
+
 def main():
     parser = argparse.ArgumentParser(description="Fetch Boston Open311 tickets to S3")
     parser.add_argument("--start", default=START_DATE, help="Start date (YYYY-MM-DD)")
@@ -317,6 +519,10 @@ def main():
     parser.add_argument("--type", default=None, help="Slug of a single type to fetch (e.g. 'needles', 'other')")
     parser.add_argument("--dry-run", action="store_true", help="Show plan without fetching")
     parser.add_argument("--delay", type=float, default=DELAY, help="Delay between requests in seconds")
+    parser.add_argument("--verify", action="store_true", help="Verify existing scraped data integrity")
+    parser.add_argument("--sample", type=float, default=None,
+                        help="Sample rate for verify mode (0.0-1.0, e.g. 0.1 for 10%%)")
+    parser.add_argument("--full", action="store_true", help="Full verify (check every day)")
     args = parser.parse_args()
 
     if not BUCKET:
@@ -337,8 +543,20 @@ def main():
         types_to_fetch = SERVICE_TYPES
 
     log.info("Date range: %s to %s", start, end)
-    log.info("Types to fetch: %s", ", ".join(types_to_fetch.keys()))
+    log.info("Types: %s", ", ".join(types_to_fetch.keys()))
 
+    # --- Verify mode ---
+    if args.verify:
+        if args.sample is not None:
+            sample_rate = max(0.0, min(1.0, args.sample))
+        elif args.full:
+            sample_rate = 1.0
+        else:
+            sample_rate = 1.0  # default to full on first run
+        run_verify(s3, types_to_fetch, start, end, args.delay, sample_rate)
+        return
+
+    # --- Normal fetch mode ---
     all_stats = []
     for slug, (service_code, name) in types_to_fetch.items():
         stats = fetch_type(s3, slug, service_code, name, start, end, args.delay, args.dry_run)


### PR DESCRIPTION
## Summary

- **Scraper**: adds `street-cleaning` slug, `--verify` mode (gap detection, record count verification, cross-day consistency), and fixes partial-page silent failure
- **Pipeline**: new `open311_loader` module bulk-loads scraped descriptions from S3; enricher tries S3 first, falls back to individual API calls for gaps
- **Storage**: fixes `list_keys` pagination bug that silently truncated results beyond 1000 keys

## What this does NOT touch

- Scott's queue-based encampment fetch, reclassification research, or `_v2_` cache keys
- Analytics, cleaner, models, classifier — zero changes
- Frontend — zero changes

## Test plan

- [x] `ruff check` passes
- [x] `mypy` strict passes
- [x] `pytest` — 7/7 tests pass
- [ ] Local MinIO: seed test day-files at `open311/street-cleaning/`, run `uv run boston-pipeline -d waste --verbose`, confirm enricher logs "loaded N descriptions from S3"
- [ ] Deploy scraper, run `python fetch.py --type street-cleaning` to start backfill
- [ ] Run `python fetch.py --verify --type needles` to validate existing scraped data

🤖 Generated with [Claude Code](https://claude.com/claude-code)