### PR TITLE
fix: hide NeighborhoodTable behind env var (default off)

### DIFF
--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -163,14 +163,16 @@ const description = `Interactive heatmap and analysis of ${formatNumber(stats.to
 			</div>
 		</section>
 
-		<NeighborhoodTable
-			client:visible
-			datasets={{
-				Sharps: { hoods: neighborhoods, yearHoods: stats.year_hoods ?? {}, years: stats.years, label: "Sharps", color: "#e85a1b" },
-				Encampments: { hoods: encampmentNeighborhoods, yearHoods: encampmentStats.year_hoods ?? {}, years: encampmentStats.years, label: "Encampments", color: "#7b2d8e" },
-				"Human Waste": { hoods: wasteNeighborhoods, yearHoods: wasteStats.year_hoods ?? {}, years: wasteStats.years, label: "Human Waste", color: "#8B6914" },
-			}}
-		/>
+		{import.meta.env.SHOW_NEIGHBORHOOD_TABLE === 'true' && (
+			<NeighborhoodTable
+				client:visible
+				datasets={{
+					Sharps: { hoods: neighborhoods, yearHoods: stats.year_hoods ?? {}, years: stats.years, label: "Sharps", color: "#e85a1b" },
+					Encampments: { hoods: encampmentNeighborhoods, yearHoods: encampmentStats.year_hoods ?? {}, years: encampmentStats.years, label: "Encampments", color: "#7b2d8e" },
+					"Human Waste": { hoods: wasteNeighborhoods, yearHoods: wasteStats.year_hoods ?? {}, years: wasteStats.years, label: "Human Waste", color: "#8B6914" },
+				}}
+			/>
+		)}
 
 		<ZipCodeList client:visible datasets={{
 			Sharps: { zipStats: stats.zip_stats, yearZips: stats.year_zips ?? {}, years: stats.years, label: "Sharps" },


### PR DESCRIPTION
## Summary
- Wraps the homepage \`NeighborhoodTable\` in a server-side gate: \`import.meta.env.SHOW_NEIGHBORHOOD_TABLE === 'true'\`
- Default behavior is **hidden** — merging this PR alone hides the table on prod, no Railway change required
- To bring the table back, set \`SHOW_NEIGHBORHOOD_TABLE=true\` on the Railway frontend service env vars

## Why
The per-neighborhood breakdown table on \`/\` is being pulled while we revisit how neighborhood-level signals are framed. Gating with an env var (rather than deleting) keeps the component and its data wiring intact for easy re-enable.

## Notes for reviewer
- Astro frontmatter / SSR — non-prefixed env var is fine here; not referenced from any \`client:\` component.
- \`astro check\` clean, \`biome format\` clean.
- No data flow changes — \`neighborhoods\`, \`encampmentNeighborhoods\`, \`wasteNeighborhoods\` are still computed; just not rendered.
- \`/neighborhoods/[slug]\` detail pages are untouched.

## Test plan
- [ ] Merge → confirm \`https://www.urbanhazardmaps.com\` no longer shows the neighborhood table between the hourly chart and zip-code list
- [ ] (Optional) Set \`SHOW_NEIGHBORHOOD_TABLE=true\` on Railway frontend → confirm table reappears after redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)