### PR TITLE
feat(B4 partial): heat-curves utility — NO live variant comparison

### DIFF
--- a/frontend/src/lib/heat-curves.ts
+++ b/frontend/src/lib/heat-curves.ts
@@ -1,0 +1,22 @@
+export type HeatCurve = "linear" | "logarithmic" | "exponential"
+
+export function linear(t: number): number {
+	const clamped = Math.max(0, Math.min(1, t))
+	return clamped
+}
+
+export function logarithmic(t: number): number {
+	const clamped = Math.max(0, Math.min(1, t))
+	return Math.log10(1 + 9 * clamped)
+}
+
+export function exponential(t: number): number {
+	const clamped = Math.max(0, Math.min(1, t))
+	return (Math.exp(clamped) - 1) / (Math.E - 1)
+}
+
+export const HEAT_CURVES: Record<HeatCurve, (t: number) => number> = {
+	linear,
+	logarithmic,
+	exponential,
+}

--- a/frontend/src/lib/heat-curves.ts
+++ b/frontend/src/lib/heat-curves.ts
@@ -1,18 +1,20 @@
 export type HeatCurve = "linear" | "logarithmic" | "exponential"
 
+function clamp01(t: number): number {
+	if (Number.isNaN(t)) return 0
+	return Math.max(0, Math.min(1, t))
+}
+
 export function linear(t: number): number {
-	const clamped = Math.max(0, Math.min(1, t))
-	return clamped
+	return clamp01(t)
 }
 
 export function logarithmic(t: number): number {
-	const clamped = Math.max(0, Math.min(1, t))
-	return Math.log10(1 + 9 * clamped)
+	return Math.log10(1 + 9 * clamp01(t))
 }
 
 export function exponential(t: number): number {
-	const clamped = Math.max(0, Math.min(1, t))
-	return (Math.exp(clamped) - 1) / (Math.E - 1)
+	return (Math.exp(clamp01(t)) - 1) / (Math.E - 1)
 }
 
 export const HEAT_CURVES: Record<HeatCurve, (t: number) => number> = {


### PR DESCRIPTION
## Scope honesty

**This PR does not close B4.** The source ticket asks for a spike: prototype 3 live variants on the same data + filter, screenshot 2 representative slices, eyeball with Andrew, pick a default, expose the others as a dev-mode toggle.

This PR ships none of that. It ships pure curve math, no UI integration. The math is the prep work for the actual spike.

## What's added

```ts
export type HeatCurve = "linear" | "logarithmic" | "exponential"
export function linear(t: number): number          // t -> t
export function logarithmic(t: number): number     // log10(1 + 9t), low-end emphasis
export function exponential(t: number): number     // (e^t - 1) / (e - 1), high-end emphasis
export const HEAT_CURVES: Record<HeatCurve, (t: number) => number>
```

All three clamp `t` to `[0, 1]` before computing.

## Provenance

Generated by the orchestrator pipeline (PR #109): Kimi K2 (full-file mode) → `pnpm build` → Codex CLI audit on the **narrowed** brief.

- Iterations: 1
- Cost: \$0.0008
- Codex verdict on narrowed brief: APPROVED
- Codex verdict on **source ticket** (re-audit): NEEDS_CHANGES — _"adds helper math, but none of the ticket's actual acceptance items: no three live variants on the same data, no screenshots, no human default pick, no dev-mode toggle"_

## Open follow-up

The actual B4 spike — wire `HEAT_CURVES` into `HeatMap.tsx`'s render path behind a `?curve=` URL param, run with two filter slices, capture screenshots, eyeball with Andrew, set the default. See the linked issue.

## Test plan

- [x] `pnpm build` clean
- [ ] `import { linear, logarithmic, exponential } from "../lib/heat-curves"` in a scratch file and confirm clamping at 0 / 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)