### PR TITLE
fix(A1): remove Roxbury 'Highest Volume Neighborhood' stat card

### DIFF
--- a/frontend/src/components/StatsOverview.astro
+++ b/frontend/src/components/StatsOverview.astro
@@ -23,18 +23,13 @@ const yearRange = years.length > 0 ? `${years[0]}\u2013${years[years.length - 1]
 		<strong>{formatNumber(total)}</strong> sharps collection requests through the city's
 		311 system, spanning <strong>{neighborhoodCount}</strong> neighborhoods. Peak activity
 		occurs on <strong>{peakDow}s</strong> around <strong>{formatHour(peakHour)}</strong>,
-		with <strong>{peakHood}</strong> consistently reporting the highest volume at an
-		average of <strong>{formatNumber(Math.round(avgMonthly))}</strong> requests per month
+		averaging <strong>{formatNumber(Math.round(avgMonthly))}</strong> requests per month
 		citywide.
 	</p>
 	<div class="stats-grid">
 		<div class="stat-card card primary">
 			<div class="stat-value">{formatNumber(total)}</div>
 			<div class="stat-label">Total Requests ({yearRange})</div>
-		</div>
-		<div class="stat-card card">
-			<div class="stat-value">{peakHood}</div>
-			<div class="stat-label">Highest Volume Neighborhood</div>
 		</div>
 		<div class="stat-card card">
 			<div class="stat-value">{formatHour(peakHour)}</div>


### PR DESCRIPTION
## Summary

Closes the **visible UI fix** in ticket A1 (`/tmp/uhm_issues/A1.md`). The Roxbury label is wrong: 311's neighborhood field tags Mass Ave corridor reports as Roxbury when they're geographically South End (zip 02118).

## Changes

`frontend/src/components/StatsOverview.astro` only:

- Removed the `<div class="stat-card card">` block whose label was "Highest Volume Neighborhood"
- Tightened the intro paragraph: dropped the `with peakHood consistently reporting the highest volume at an` sub-clause; collapsed to `averaging N requests per month citywide.`

The `peakHood` prop is left in the `Props` interface — still passed by `index.astro`, just unused inside the component.

## ⚠️ Merge order with #113

Both this PR and #113 modify `frontend/src/components/StatsOverview.astro` in the stat-grid section. Whichever lands first, the other needs a quick rebase. Suggested order: **#112 first, then #113** (this PR is smaller).

## ⚠️ Source-ticket follow-up not yet tracked

The A1 source spec includes:
> Open follow-up: investigate why neighborhood field in 311 data disagrees with coordinates (likely a Boston-side fix to flag).

A separate issue should be opened for that investigation; this PR only ships the visible removal.

## Provenance

Orchestrator pipeline (PR #109): Kimi K2 (full-file mode) → `pnpm build` → Codex CLI audit on narrowed brief.

- Iterations: 1
- Cost: \$0.0024
- Codex on narrowed brief: APPROVED
- Codex on **source ticket** (re-audit): NEEDS_CHANGES because the follow-up was silently dropped

## Test plan

- [x] `pnpm build` clean
- [ ] `pnpm dev` and confirm five stat cards remain, intro reads naturally

🤖 Generated with [Claude Code](https://claude.com/claude-code)