### PR TITLE
fix(A2): hide HourlyChart + Peak Hour of Day stat card

### DIFF
--- a/frontend/src/components/StatsOverview.astro
+++ b/frontend/src/components/StatsOverview.astro
@@ -1,5 +1,5 @@
 ---
-import { formatHour, formatNumber } from "../lib/seo"
+import { formatNumber } from "../lib/seo"
 
 interface Props {
 	total: number
@@ -11,7 +11,7 @@ interface Props {
 	years: number[]
 }
 
-const { total, peakHood, peakHour, peakDow, avgMonthly, neighborhoodCount, years } = Astro.props
+const { total, peakDow, avgMonthly, neighborhoodCount, years } = Astro.props
 
 const yearRange = years.length > 0 ? `${years[0]}\u2013${years[years.length - 1]}` : "N/A"
 ---
@@ -22,18 +22,13 @@ const yearRange = years.length > 0 ? `${years[0]}\u2013${years[years.length - 1]
 		Between <strong>{yearRange}</strong>, Boston residents submitted
 		<strong>{formatNumber(total)}</strong> sharps collection requests through the city's
 		311 system, spanning <strong>{neighborhoodCount}</strong> neighborhoods. Peak activity
-		occurs on <strong>{peakDow}s</strong> around <strong>{formatHour(peakHour)}</strong>,
-		averaging <strong>{formatNumber(Math.round(avgMonthly))}</strong> requests per month
-		citywide.
+		occurs on <strong>{peakDow}s</strong>, averaging
+		<strong>{formatNumber(Math.round(avgMonthly))}</strong> requests per month citywide.
 	</p>
 	<div class="stats-grid">
 		<div class="stat-card card primary">
 			<div class="stat-value">{formatNumber(total)}</div>
 			<div class="stat-label">Total Requests ({yearRange})</div>
-		</div>
-		<div class="stat-card card">
-			<div class="stat-value">{formatHour(peakHour)}</div>
-			<div class="stat-label">Peak Hour of Day</div>
 		</div>
 		<div class="stat-card card">
 			<div class="stat-value">{peakDow}</div>

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -2,7 +2,6 @@
 import Footer from "../components/Footer.astro"
 import Header from "../components/Header.astro"
 import HeatMap from "../components/HeatMap"
-import HourlyChart from "../components/HourlyChart"
 import MonthlyTrend from "../components/MonthlyTrend"
 import NeighborhoodTable from "../components/NeighborhoodTable"
 import StatsOverview from "../components/StatsOverview.astro"
@@ -137,29 +136,6 @@ const description = `Interactive heatmap and analysis of ${formatNumber(stats.to
 					Encampments: { yearMonthly: encampmentStats.year_monthly, label: "Encampments" },
 					"Human Waste": { yearMonthly: wasteStats.year_monthly, label: "Human Waste" },
 				}} />
-				<HourlyChart
-					client:visible
-					datasets={{
-						Sharps: {
-							hourly: stats.hourly, yearHourly: stats.year_hourly,
-							hoodHourly: stats.hood_hourly ?? {}, zipHourly: stats.zip_hourly ?? {},
-							years: stats.years,
-							hoods: stats.hoods.map(h => h.name), zips: stats.zip_stats.map(z => z.zip),
-						},
-						Encampments: {
-							hourly: encampmentStats.hourly, yearHourly: encampmentStats.year_hourly,
-							hoodHourly: encampmentStats.hood_hourly ?? {}, zipHourly: encampmentStats.zip_hourly ?? {},
-							years: encampmentStats.years,
-							hoods: encampmentStats.hoods.map(h => h.name), zips: encampmentStats.zip_stats.map(z => z.zip),
-						},
-						"Human Waste": {
-							hourly: wasteStats.hourly, yearHourly: wasteStats.year_hourly,
-							hoodHourly: wasteStats.hood_hourly ?? {}, zipHourly: wasteStats.zip_hourly ?? {},
-							years: wasteStats.years,
-							hoods: wasteStats.hoods.map(h => h.name), zips: wasteStats.zip_stats.map(z => z.zip),
-						},
-					}}
-				/>
 			</div>
 		</section>
 

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -215,7 +215,7 @@ const description = `Interactive heatmap and analysis of ${formatNumber(stats.to
 
 	.charts-grid {
 		display: grid;
-		grid-template-columns: 1fr 1fr;
+		grid-template-columns: 1fr;
 		gap: 20px;
 	}
 


### PR DESCRIPTION
## Summary

Hides the visible surfaces from ticket A2: the "Requests by Hour of Day" chart and the "Peak Hour of Day" stat card. Both were surfacing a 12 AM peak suspected to be an artifact of bulk-loaded ticket timestamps.

## Changes

- `frontend/src/pages/index.astro`: drop the `HourlyChart` import and the `<HourlyChart …/>` element
- `frontend/src/components/StatsOverview.astro`: remove the "Peak Hour of Day" stat card

`peakHour` prop on `StatsOverview` left in the interface — still passed from `index.astro`, just unused inside the component.

## ⚠️ Merge order with #112

This PR and #112 both modify `frontend/src/components/StatsOverview.astro` in the stat-grid section. Suggested order: **#112 first, then rebase this PR** (this is the larger of the two changes).

## ⚠️ Source-ticket scope NOT in this PR

The A2 source spec also includes:

- [ ] **Add a brief Data Quality page note** explaining that hour-of-day is under investigation
- [ ] **Open follow-up: diagnose the overnight spike** (separate ticket)

Suggested copy for the data-quality note (drop between the breadcrumb and the page title in `frontend/src/pages/data-quality.astro`):

```html
<section>
    <h2>Hour-of-day data temporarily hidden</h2>
    <p>
        We've removed the hour-of-day chart and the related stat from the home page
        while we investigate an apparent overnight spike that is unlikely to reflect
        actual reporting times. Likely causes include bulk-loaded ticket timestamps;
        we'll restore the chart once we can show it accurately.
    </p>
</section>
```

The note is deferred to manual follow-up because `data-quality.astro` is 600+ lines and full-file regeneration introduces transcription errors at that size (caught Apr 2026: K2 turned `border-radius: 2px;` into `border-radius: px;`).

## Provenance

Orchestrator pipeline (PR #109): Kimi K2 (full-file mode) → `pnpm build` → Codex CLI audit on narrowed brief.

- Iterations: 3
- Cost: \$0.028
- Codex on narrowed brief: NEEDS_CHANGES — flagged a 1-character CSS selector typo (`page-title::::after` → `page-title::after`), hand-corrected before commit. Otherwise matches the narrowed scope.
- Codex on **source ticket** (re-audit): NEEDS_CHANGES because the data-quality note + spike-diagnosis follow-up were silently dropped.

## Test plan

- [x] `pnpm build` clean (after typo fix)
- [ ] `pnpm dev` and confirm hour chart gone, page title underline still renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)