### PR TITLE
fix(C1 partial): disable map panning — broader UI audit deferred

### DIFF
--- a/frontend/src/components/HeatMap.tsx
+++ b/frontend/src/components/HeatMap.tsx
@@ -316,6 +316,7 @@ export default function HeatMap({
 				center: [42.332, -71.078],
 				zoom: 13,
 				dragging: false,
+				keyboardPanDelta: 0,
 			})
 			mapInstance.current = map
 

--- a/frontend/src/components/HeatMap.tsx
+++ b/frontend/src/components/HeatMap.tsx
@@ -312,7 +312,11 @@ export default function HeatMap({
 			}
 
 			if (!mapRef.current) return
-			const map = L.map(mapRef.current, { center: [42.332, -71.078], zoom: 13 })
+			const map = L.map(mapRef.current, {
+				center: [42.332, -71.078],
+				zoom: 13,
+				dragging: false,
+			})
 			mapInstance.current = map
 
 			// Custom panes so boundaries always render above heatmaps


### PR DESCRIPTION
## Summary

Closes the **first acceptance bullet** of ticket C1 (`/tmp/uhm_issues/C1.md`): disable map panning, keep zoom. Per Andrew on the 2026-04-29 call: panning adds no value for the public viewer (data fits the default frame; panning lets viewers get lost).

## Changes

`frontend/src/components/HeatMap.tsx` — single config change to the Leaflet map options:

\`\`\`diff
-			const map = L.map(mapRef.current, { center: [42.332, -71.078], zoom: 13 })
+			const map = L.map(mapRef.current, {
+				center: [42.332, -71.078],
+				zoom: 13,
+				dragging: false,
+			})
\`\`\`

## ⚠️ Source-ticket scope NOT in this PR

C1 has five other acceptance bullets, none of which are touched by this PR:

- [ ] Audit every control on the page; for each, "does a non-technical viewer benefit from this?" — hide those that fail
- [ ] On click of a region: filter charts and reveal pins for that region (interacts with #98 / B2)
- [ ] Hover should preview only; click should commit the filter
- [ ] Document what was removed in a brief Methodology note

Each of these needs careful work inside `HeatMap.tsx` and should be a separate PR. See the linked issue for tracking.

## Provenance

**Done by hand**, not via the Kimi orchestrator. `HeatMap.tsx` is 1,485 lines, well beyond the documented file-size limit for safe full-file regeneration. The orchestrator did attempt C1 first (3 iterations, all parse failures, $0.089 wasted) before the autonomous run gave up — the file-size check should hard-refuse oversized tickets, tracked as a follow-up to #109.

## Test plan

- [x] `pnpm build` clean
- [ ] `pnpm dev` and confirm:
  - Map zooms with mouse wheel + buttons
  - Cannot drag/pan the map
  - Boundaries, heatmap, and markers still render

🤖 Generated with [Claude Code](https://claude.com/claude-code)