### PR TITLE
ci: scope secret-scan to PR diff (fixes failing scan on every PR)

### DIFF
--- a/.github/trufflehog-excludes.txt
+++ b/.github/trufflehog-excludes.txt
@@ -1,0 +1,9 @@
+# Paths excluded from TruffleHog secret scanning. One regex per line.
+#
+# Defense-in-depth alongside the BASE..HEAD scope in pr.yml — anything
+# in this list is also skipped if it slips into a PR diff.
+#
+# These are test fixtures that contain credential-shaped strings BY DESIGN
+# (the strings exercise the redactor in scripts/orchestrator/scrub.py).
+# Real secrets must never be added here — review carefully on every change.
+scripts/orchestrator/tests/test_scrub\.py$

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -119,11 +119,38 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          # fetch-depth: 0 fetches ALL branches into the local clone. With
+          # `--no-update --fail`, trufflehog then scanned credential-shaped
+          # strings in unrelated branches' history (e.g. test fixtures on
+          # the orchestrator branch) and failed every PR. Use depth 2 so
+          # we have one commit of context for the diff range and nothing
+          # else.
+          fetch-depth: 2
+      - name: Determine PR commit range
+        id: range
+        run: |
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          # Make sure the base commit is fetched so trufflehog can diff
+          # against it. With fetch-depth: 2 the base may not be present.
+          git fetch --depth=1 origin "$BASE_SHA" || true
+          echo "base=$BASE_SHA" >> "$GITHUB_OUTPUT"
+          echo "head=$HEAD_SHA" >> "$GITHUB_OUTPUT"
       - name: Pull trufflehog Docker image
         run: docker pull ghcr.io/trufflesecurity/trufflehog:latest
-      - name: Run trufflehog scan
-        run: docker run --rm -v "$PWD:/repo" ghcr.io/trufflesecurity/trufflehog:latest git file:///repo --fail --no-update
+      - name: Run trufflehog scan (PR diff only)
+        # Scan only commits the PR introduces (BASE..HEAD). Pre-existing
+        # credential-shaped content in main's history is not the PR's
+        # responsibility — that lives in the rotate-and-block-with-push-
+        # protection layer, not in PR CI.
+        run: |
+          docker run --rm -v "$PWD:/repo" ghcr.io/trufflesecurity/trufflehog:latest \
+            git file:///repo \
+            --since-commit=${{ steps.range.outputs.base }} \
+            --branch=${{ steps.range.outputs.head }} \
+            --fail \
+            --no-update \
+            --exclude-paths=/repo/.github/trufflehog-excludes.txt
 
   notify-on-secret-found:
     name: Notify on secret found


### PR DESCRIPTION
## Summary

- Scope trufflehog to `BASE..HEAD` of the PR instead of full repo history
- Add `.github/trufflehog-excludes.txt` for defense-in-depth on intentional credential-shaped fixtures

## Why this matters

The current secret-scan workflow runs `trufflehog ... --no-update --fail` against the full git history with `actions/checkout@v4 + fetch-depth: 0`. That fetches **all** branches into the runner's local clone. TruffleHog then scans every commit on every branch and fails on credential-shaped strings in unrelated branches' history.

Concretely: PRs #110–#114 (kimi/*) all fail this check. Their diffs are tiny and obviously secret-free, but the orchestrator branch (`chore/orchestrator-scaffolding`) has scrubber test fixtures with strings like `postgresql://user:hunter2@db.internal:5432/prod` — credential-shaped on purpose so they exercise the redactor. Trufflehog scans those commits even from kimi PR runs and exits 183.

## What changed

1. `actions/checkout@v4`: `fetch-depth: 2` instead of `0` — only enough to compute the diff range.
2. New step explicitly fetches the PR base SHA so trufflehog can diff against it.
3. trufflehog command now uses `--since-commit=$BASE --branch=$HEAD` to scope to the PR's commits.
4. trufflehog command also passes `--exclude-paths=/repo/.github/trufflehog-excludes.txt` for defense-in-depth.
5. New `.github/trufflehog-excludes.txt` excludes `scripts/orchestrator/tests/test_scrub.py` (the only known intentional-fixture path).

## Test plan

Locally with trufflehog 3.95.2 in a fresh clone:
- Scanning the workflow-fix PR's own diff: `chunks: 5, bytes: 4365, 0 secrets, 0 unverified` — clean pass.
- Scanning kimi/A2 against main with the new flags: `chunks: 12, bytes: 3758, 0 secrets, 0 unverified` — clean pass.
- Compare to the original failing run on PR #110: `chunks: 1171, bytes: 3332804, 1 unverified` — 230× more content scanned because of full-history.

## Process learning

PR-CI secret scans should be PR-scoped, not full-history. Pre-existing credentials in repo history are the **rotate-and-block-with-push-protection** layer's job, not the per-PR check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)