### PR TITLE
fix(B2): hide pins by default + tune basemap opacity + filter-stable

### DIFF
--- a/frontend/src/components/HeatMap.tsx
+++ b/frontend/src/components/HeatMap.tsx
@@ -169,7 +169,7 @@ export default function HeatMap({
 	const [ready, setReady] = useState(false)
 	const [isMobile, setIsMobile] = useState(false)
 	const [filterOpen, setFilterOpen] = useState(false)
-	const [showPins, setShowPins] = useState(true)
+	const [showPins, setShowPins] = useState(false)
 	const [showBoundaries, setShowBoundaries] = useState<BoundaryLayer | null>(null)
 	const [heatIntensity, setHeatIntensity] = useState(50)
 	const heatIntensityRef = useRef(50)
@@ -331,6 +331,7 @@ export default function HeatMap({
 					'&copy; <a href="https://carto.com/">CARTO</a> &middot; <a href="https://www.openstreetmap.org/copyright">OSM</a>',
 				subdomains: "abcd",
 				maxZoom: 19,
+				opacity: 0.7,
 			}).addTo(map)
 
 			// Both heat layers on by default, filtered to latest year

--- a/frontend/src/components/HeatMap.tsx
+++ b/frontend/src/components/HeatMap.tsx
@@ -809,7 +809,7 @@ export default function HeatMap({
 		}
 
 		// Rebuild markers with new filter
-		if (map.getZoom() >= 15) {
+		if (showPins && map.getZoom() >= 15) {
 			rebuildMarkers(map)
 		}
 	}, [


### PR DESCRIPTION
## Summary

- Default-hide pins at all zoom levels (showPins initial state false)
- Tune CARTO basemap opacity to 0.7 so street labels read through the heatmap
- Gate filter-change marker rebuild on showPins so the hidden state survives filter toggles at zoom 15+

## Why

From the 2026-04-29 call (recording 38:03–39:41): individual red point markers between clusters create false-looking spikes that hide the underlying gradient (\"the red dots between the locations are hiding the trend\"). Andrew also noted Tableau tunes basemap transparency deliberately so labels read through the heat layer.

## Test plan

- [x] biome check passes
- [x] astro check passes (0 errors / 0 warnings / 0 hints)
- [x] pnpm build passes
- [x] Codex audit: APPROVED (\"Three surgical edits only; they match the authorized lines, close the lone ungated filter-triggered marker rebuild\")

## Out of scope (deferred to follow-up)

The source ticket B2 also asks for a click/select interaction that reveals individual ticket points for a selected region. That requires net-new click handlers on the boundary GeoJSON layer plus pin-management state. Paired with the C1 region-click deferral and #98.

## Implementation notes

Hand-applied (not orchestrator-dispatched) — HeatMap.tsx is 1,485 lines, well past the safe full-file regen size. Surgical edits + Codex audit per the May 2026 calibration lessons. Codex caught a real regression in iteration 1 (filter-change marker rebuild was unconditional) which is fixed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)