### PR TITLE
fix: hide Neighborhoods Reporting stat card (unreliable 311 data)

### DIFF
--- a/frontend/src/components/StatsOverview.astro
+++ b/frontend/src/components/StatsOverview.astro
@@ -11,7 +11,7 @@ interface Props {
 	years: number[]
 }
 
-const { total, peakDow, avgMonthly, neighborhoodCount, years } = Astro.props
+const { total, peakDow, avgMonthly, years } = Astro.props
 
 const yearRange = years.length > 0 ? `${years[0]}\u2013${years[years.length - 1]}` : "N/A"
 ---
@@ -21,8 +21,7 @@ const yearRange = years.length > 0 ? `${years[0]}\u2013${years[years.length - 1]
 	<p class="stats-intro">
 		Between <strong>{yearRange}</strong>, Boston residents submitted
 		<strong>{formatNumber(total)}</strong> sharps collection requests through the city's
-		311 system, spanning <strong>{neighborhoodCount}</strong> neighborhoods. Peak activity
-		occurs on <strong>{peakDow}s</strong>, averaging
+		311 system. Peak activity occurs on <strong>{peakDow}s</strong>, averaging
 		<strong>{formatNumber(Math.round(avgMonthly))}</strong> requests per month citywide.
 	</p>
 	<div class="stats-grid">
@@ -37,10 +36,6 @@ const yearRange = years.length > 0 ? `${years[0]}\u2013${years[years.length - 1]
 		<div class="stat-card card">
 			<div class="stat-value">{formatNumber(Math.round(avgMonthly))}</div>
 			<div class="stat-label">Average Monthly Requests</div>
-		</div>
-		<div class="stat-card card">
-			<div class="stat-value">{neighborhoodCount}</div>
-			<div class="stat-label">Neighborhoods Reporting</div>
 		</div>
 	</div>
 </section>


### PR DESCRIPTION
## Summary

- Drop the "Neighborhoods Reporting" stat card from StatsOverview
- Drop "spanning N neighborhoods" from the intro paragraph (same data source)
- Drop \`neighborhoodCount\` from destructure (Props keeps it — callers still pass)

## Why

Brian's feedback after the wave-1 visual review: the count is dumb to surface — same root cause as the A1 Roxbury card removal. The 311 \`neighborhood\` field is unreliable (blank values, "Allston" vs "Allston / Brighton" inconsistencies, Mass-Ave-corridor mislabels per docs/wiki/data-quality-issues.md §8). A count of distinct values is therefore misleading.

After this lands, three stat cards remain: Total Requests, Busiest Day of Week, Average Monthly Requests.

## Test plan

- [x] biome check / format pass
- [x] astro check: 0 errors / 0 warnings / 0 hints
- [ ] Visual on deployed site after merge: confirm 3 cards rendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)