### PR TITLE
feat: shared filter store — foundation for universal cross-filtering (#20)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,9 +17,11 @@
     "@astrojs/node": "^10.0.4",
     "@astrojs/react": "^5.0.2",
     "@aws-sdk/client-s3": "^3.1024.0",
+    "@nanostores/react": "^1.1.0",
     "astro": "^6.1.3",
     "chart.js": "^4.5.1",
     "leaflet": "^1.9.4",
+    "nanostores": "^1.3.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "typescript": "~5.8.3"

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@aws-sdk/client-s3':
         specifier: ^3.1024.0
         version: 3.1024.0
+      '@nanostores/react':
+        specifier: ^1.1.0
+        version: 1.1.0(nanostores@1.3.0)(react@19.2.4)
       astro:
         specifier: ^6.1.3
         version: 6.1.3(@types/node@24.12.2)(rollup@4.60.1)(typescript@5.8.3)(yaml@2.8.3)
@@ -29,6 +32,9 @@ importers:
       leaflet:
         specifier: ^1.9.4
         version: 1.9.4
+      nanostores:
+        specifier: ^1.3.0
+        version: 1.3.0
       react:
         specifier: ^19.2.4
         version: 19.2.4
@@ -769,6 +775,13 @@ packages:
 
   '@kurkle/color@0.3.4':
     resolution: {integrity: sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==}
+
+  '@nanostores/react@1.1.0':
+    resolution: {integrity: sha512-MbH35fjhcf7LAubYX5vhOChYUfTLzNLqH/mBGLVsHkcvjy0F8crO1WQwdmQ2xKbAmtpalDa2zBt3Hlg5kqr8iw==}
+    engines: {node: ^20.0.0 || >=22.0.0}
+    peerDependencies:
+      nanostores: ^1.2.0
+      react: '>=18.0.0'
 
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
@@ -1859,6 +1872,10 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  nanostores@1.3.0:
+    resolution: {integrity: sha512-XPUa/jz+P1oJvN9VBxw4L9MtdFfaH3DAryqPssqhb2kXjmb9npz0dly6rCsgFWOPr4Yg9mTfM3MDZgZZ+7A3lA==}
+    engines: {node: ^20.0.0 || >=22.0.0}
 
   neotraverse@0.6.18:
     resolution: {integrity: sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==}
@@ -3452,6 +3469,11 @@ snapshots:
 
   '@kurkle/color@0.3.4': {}
 
+  '@nanostores/react@1.1.0(nanostores@1.3.0)(react@19.2.4)':
+    dependencies:
+      nanostores: 1.3.0
+      react: 19.2.4
+
   '@oslojs/encoding@1.1.0': {}
 
   '@rolldown/pluginutils@1.0.0-rc.3': {}
@@ -4916,6 +4938,8 @@ snapshots:
   muggle-string@0.4.1: {}
 
   nanoid@3.3.11: {}
+
+  nanostores@1.3.0: {}
 
   neotraverse@0.6.18: {}
 

--- a/frontend/src/components/NeighborhoodTable.tsx
+++ b/frontend/src/components/NeighborhoodTable.tsx
@@ -1,4 +1,6 @@
+import { useStore } from "@nanostores/react"
 import { useEffect, useMemo, useState } from "react"
+import { $dataLayer, $year, type DataLayer, setDataLayer, setYear } from "../lib/filterStore"
 
 interface NeighborhoodStat {
 	name: string
@@ -32,9 +34,11 @@ function formatNumber(n: number): string {
 }
 
 export default function NeighborhoodTable({ datasets }: NeighborhoodTableProps) {
-	const types = Object.keys(datasets)
-	const [activeType, setActiveType] = useState(types[0])
-	const [activeYear, setActiveYear] = useState("all")
+	const types = Object.keys(datasets) as DataLayer[]
+	const dataLayer = useStore($dataLayer)
+	const year = useStore($year)
+	const activeType: DataLayer = types.includes(dataLayer) ? dataLayer : types[0]
+	const activeYearKey = year === "all" ? "all" : String(year)
 	const [windowWidth, setWindowWidth] = useState(1024)
 
 	useEffect(() => {
@@ -49,7 +53,7 @@ export default function NeighborhoodTable({ datasets }: NeighborhoodTableProps) 
 
 	const dataset = datasets[activeType]
 	const hoods =
-		activeYear === "all" ? (dataset?.hoods ?? []) : (dataset?.yearHoods[activeYear] ?? [])
+		activeYearKey === "all" ? (dataset?.hoods ?? []) : (dataset?.yearHoods[activeYearKey] ?? [])
 	const years = dataset?.years ?? []
 	const color = TYPE_COLORS[activeType] || "#e85a1b"
 
@@ -66,7 +70,7 @@ export default function NeighborhoodTable({ datasets }: NeighborhoodTableProps) 
 						key={t}
 						type="button"
 						aria-label={`Show ${t} neighborhood data`}
-						onClick={() => setActiveType(t)}
+						onClick={() => setDataLayer(t)}
 						style={{
 							padding: "4px 12px",
 							fontSize: "12px",
@@ -92,17 +96,17 @@ export default function NeighborhoodTable({ datasets }: NeighborhoodTableProps) 
 					<button
 						type="button"
 						aria-label="Show all years"
-						onClick={() => setActiveYear("all")}
+						onClick={() => setYear("all")}
 						style={{
 							padding: "2px 8px",
 							fontSize: "10px",
 							border: "1px solid #ccc",
 							borderRadius: "10px",
-							background: activeYear === "all" ? "#555" : "transparent",
-							color: activeYear === "all" ? "#fff" : "#666",
+							background: activeYearKey === "all" ? "#555" : "transparent",
+							color: activeYearKey === "all" ? "#fff" : "#666",
 							cursor: "pointer",
 							fontFamily: "inherit",
-							fontWeight: activeYear === "all" ? 600 : 400,
+							fontWeight: activeYearKey === "all" ? 600 : 400,
 						}}
 					>
 						All Years
@@ -112,17 +116,17 @@ export default function NeighborhoodTable({ datasets }: NeighborhoodTableProps) 
 							key={y}
 							type="button"
 							aria-label={`Show year ${y}`}
-							onClick={() => setActiveYear(String(y))}
+							onClick={() => setYear(y)}
 							style={{
 								padding: "2px 8px",
 								fontSize: "10px",
 								border: "1px solid #ccc",
 								borderRadius: "10px",
-								background: activeYear === String(y) ? "#555" : "transparent",
-								color: activeYear === String(y) ? "#fff" : "#666",
+								background: activeYearKey === String(y) ? "#555" : "transparent",
+								color: activeYearKey === String(y) ? "#fff" : "#666",
 								cursor: "pointer",
 								fontFamily: "inherit",
-								fontWeight: activeYear === String(y) ? 600 : 400,
+								fontWeight: activeYearKey === String(y) ? 600 : 400,
 							}}
 						>
 							{y}

--- a/frontend/src/components/ZipCodeList.tsx
+++ b/frontend/src/components/ZipCodeList.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react"
+import { useStore } from "@nanostores/react"
+import { $dataLayer, $year, type DataLayer, setDataLayer, setYear } from "../lib/filterStore"
 import type { ZipStat } from "../lib/types"
 
 interface DatasetZips {
@@ -23,13 +24,15 @@ function formatNumber(n: number): string {
 }
 
 export default function ZipCodeList({ datasets }: ZipCodeListProps) {
-	const types = Object.keys(datasets)
-	const [activeType, setActiveType] = useState(types[0])
-	const [activeYear, setActiveYear] = useState("all")
+	const types = Object.keys(datasets) as DataLayer[]
+	const dataLayer = useStore($dataLayer)
+	const year = useStore($year)
+	const activeType: DataLayer = types.includes(dataLayer) ? dataLayer : types[0]
+	const activeYearKey = year === "all" ? "all" : String(year)
 
 	const dataset = datasets[activeType]
 	const zipStats =
-		activeYear === "all" ? (dataset?.zipStats ?? []) : (dataset?.yearZips[activeYear] ?? [])
+		activeYearKey === "all" ? (dataset?.zipStats ?? []) : (dataset?.yearZips[activeYearKey] ?? [])
 	const years = dataset?.years ?? []
 	const maxCount = zipStats[0]?.count ?? 1
 	const color = TYPE_COLORS[activeType] || "#76b7b2"
@@ -45,7 +48,7 @@ export default function ZipCodeList({ datasets }: ZipCodeListProps) {
 							key={t}
 							type="button"
 							aria-label={`Show ${t} zip code data`}
-							onClick={() => setActiveType(t)}
+							onClick={() => setDataLayer(t)}
 							style={{
 								padding: "4px 12px",
 								fontSize: "12px",
@@ -72,17 +75,17 @@ export default function ZipCodeList({ datasets }: ZipCodeListProps) {
 					<button
 						type="button"
 						aria-label="Show all years"
-						onClick={() => setActiveYear("all")}
+						onClick={() => setYear("all")}
 						style={{
 							padding: "2px 8px",
 							fontSize: "10px",
 							border: "1px solid #ccc",
 							borderRadius: "10px",
-							background: activeYear === "all" ? "#555" : "transparent",
-							color: activeYear === "all" ? "#fff" : "#666",
+							background: activeYearKey === "all" ? "#555" : "transparent",
+							color: activeYearKey === "all" ? "#fff" : "#666",
 							cursor: "pointer",
 							fontFamily: "inherit",
-							fontWeight: activeYear === "all" ? 600 : 400,
+							fontWeight: activeYearKey === "all" ? 600 : 400,
 						}}
 					>
 						All Years
@@ -92,17 +95,17 @@ export default function ZipCodeList({ datasets }: ZipCodeListProps) {
 							key={y}
 							type="button"
 							aria-label={`Show year ${y}`}
-							onClick={() => setActiveYear(String(y))}
+							onClick={() => setYear(y)}
 							style={{
 								padding: "2px 8px",
 								fontSize: "10px",
 								border: "1px solid #ccc",
 								borderRadius: "10px",
-								background: activeYear === String(y) ? "#555" : "transparent",
-								color: activeYear === String(y) ? "#fff" : "#666",
+								background: activeYearKey === String(y) ? "#555" : "transparent",
+								color: activeYearKey === String(y) ? "#fff" : "#666",
 								cursor: "pointer",
 								fontFamily: "inherit",
-								fontWeight: activeYear === String(y) ? 600 : 400,
+								fontWeight: activeYearKey === String(y) ? 600 : 400,
 							}}
 						>
 							{y}

--- a/frontend/src/lib/filterStore.ts
+++ b/frontend/src/lib/filterStore.ts
@@ -1,0 +1,24 @@
+import { atom } from "nanostores"
+
+export type DataLayer = "Sharps" | "Encampments" | "Human Waste"
+
+// "all" is shared across components — a numeric 0 sentinel would leak HeatMap's
+// historical convention into the table components.
+export type YearFilter = number | "all"
+export type MonthFilter = number | "all"
+
+export const $dataLayer = atom<DataLayer>("Sharps")
+export const $year = atom<YearFilter>("all")
+export const $month = atom<MonthFilter>("all")
+
+export function setDataLayer(layer: DataLayer): void {
+	$dataLayer.set(layer)
+}
+
+export function setYear(year: YearFilter): void {
+	$year.set(year)
+}
+
+export function setMonth(month: MonthFilter): void {
+	$month.set(month)
+}


### PR DESCRIPTION
## Summary

Foundation PR for #20 (universal cross-filtering). Adds `@nanostores/react` as Astro's cross-island state bus and migrates the two simplest components (`ZipCodeList`, `NeighborhoodTable`) to read/write a shared store of `$dataLayer × $year × $month`.

**Why tag Scott:** this PR introduces a cross-island state pattern that every dashboard component will eventually consume. The architecture call is worth a second look before the HeatMap / MonthlyTrend / StatsOverview migrations follow.

## Architecture decisions (the part worth reviewing)

### 1. nanostores over React context
React context can't cross Astro island boundaries — each `client:` directive mounts an independent React root. The documented Astro pattern for cross-island reactive state is nanostores + `@nanostores/react`. Alternative considered: wrap all islands in one big React root, but that forces HeatMap (Leaflet, heavy) into the same bundle as the trend chart — bad for TTI.

### 2. Single-select `$dataLayer`, no multi-select
`DataLayer = "Sharps" | "Encampments" | "Human Waste"`. The HeatMap's existing `"both"` mode is a *map view choice*, not a shared filter concept — it'll be handled as local heatmap state in the HeatMap-migration PR. Open question for that PR: drop `"both"` entirely for cross-component coherence, or keep it as a heatmap-only stacking option? Flagging now so we can decide before that PR lands.

### 3. Numeric `YearFilter = number | "all"`, `MonthFilter = number | "all"`
Components today use stringified years (`"2024"`). Conversion is done at the button-click / render boundary; the store is canonical numeric.

### 4. Defaults: `dataLayer="Sharps"`, `year="all"`, `month="all"`
Matches existing table defaults. HeatMap currently defaults to latest-year — that behavior will need to migrate either into store-init logic or be overridden by #126 (call-decided defaults). Flagging.

## What's in this PR

- `frontend/src/lib/filterStore.ts` — atoms + typed setters (24 lines)
- `package.json` — `nanostores ^1.3.0`, `@nanostores/react ^1.1.0`
- `ZipCodeList.tsx` — `useState` → `useStore`; click handlers call `setDataLayer` / `setYear`
- `NeighborhoodTable.tsx` — same migration

## What's NOT in this PR (deliberately)

- **HeatMap migration** — biggest surface, needs the `"both"` mode decision
- **MonthlyTrend** — adds year filter (out of scope: this is a refactor PR, not a feature PR)
- **StatsOverview** — `.astro` → `.tsx` conversion, separate risk profile
- **Frontend test infra (vitest)** — will file as follow-up issue; this PR was verified via `pnpm dev` + browser

## Verification

- `pnpm check` — 0 errors, 0 warnings (biome + astro check)
- `pnpm build` — clean, server bundle built in 2.23s
- Browser-tested via `agent-browser`:
  - Clicked Encampments in ZipCodeList → store updated → button activates correctly
  - Clicked 2024 in ZipCodeList → year atom updates → row counts re-render
  - `NeighborhoodTable` is env-gated (`SHOW_NEIGHBORHOOD_TABLE !== 'true'` in default config), so visible cross-component sync will be demonstrated in the HeatMap-migration PR where both subscribers are visible by default.

## Follow-ups
- [ ] HeatMap migration (with `"both"` mode disposition decided)
- [ ] MonthlyTrend year-filter addition
- [ ] StatsOverview .astro → .tsx conversion
- [ ] Frontend test infra (vitest) — new issue to file

🤖 Generated with [Claude Code](https://claude.com/claude-code)